### PR TITLE
Music Data

### DIFF
--- a/Task5/SQL/SQL code/Webseries
+++ b/Task5/SQL/SQL code/Webseries
@@ -94,8 +94,8 @@ ORDER BY r.series_name, r.rank;
 --Display: series name, episode title, longevity score, episode label, episode count, recent genres, total seasons per series.
 --Order by series name, longevity score (descending).
 --Expected Output:
---series_name	episode_title	longevity_score	episode_label	episode_count	recent_genres	total_seasons
---Breaking Bad	No Más	        31.50	        Long-Lasting	3		Action, Sci-Fi	3
+--series_name	episode_title	longevity_score	 episode_label	episode_count	recent_genres	  total_seasons
+--Breaking Bad	No Más	        31.50	          Long-Lasting	3		         Action, Sci-Fi	    3
 
 
 -- Step 1: Create function
@@ -173,8 +173,8 @@ ORDER BY ls.series_name, ls.longevity_score DESC;
 --Display: series name, episode title, consistency score, consistency category, season rank, recent episodes, max series rating.
 --Order by series name, consistency score.
 --Expected Output:
---series_name	episode_title	consistency_score	consistency_category	season_rank	recent_episodes		max_series_rating
---Breaking Bad	Seven 		Thirty-Seven		1.00			Consistent	1			8.7
+--series_name	episode_title	   consistency_score	consistency_category	season_rank	 recent_episodes		     max_series_rating
+--Breaking Bad	Seven Thirty-Seven		1.00		      Consistent	             1		 as alphabetical order         8.7
 
 
 --(Create the function)

--- a/Task5/SQL/SQL code/music
+++ b/Task5/SQL/SQL code/music
@@ -1,0 +1,161 @@
+select * from music.music_track;
+--Task 1: Genre Popularity Aggregation
+--Objective: Rank tracks by play count within genres and aggregate popular tracks.
+--Task Description: Without Function
+--Calculate a popularity metric: play_count ÷ 100,000, rounded to 2 decimals. Use 0 for null play_count.
+--Categorize tracks: ‘Hit’ if metric ≥ 15, ‘Known’ if ≥ 10, else ‘Underrated’.
+--Use a window function to rank tracks by play_count within each genre (highest = rank 1).
+--Use STRING_AGG to list track names (alphabetically) with rating ≥ 4.5 per genre, comma-separated, or ‘None’ if none.
+--Show: track name, genre, popularity metric, category, genre rank, high-rated tracks.
+--Order by genre, genre rank.
+--Expected Output:
+--track_name	        genre  	popularity_metric	track_category	genre_rank	     high_rated_tracks
+--Blinding Lights	     Pop	    25.00	            Hit	            1	        Billie Jean, Blinding Lights
+
+WITH Popularity AS (
+    SELECT 
+        track_name,
+        genre,
+        ROUND(COALESCE(play_count, 0) / 100000, 2) AS popularity_metric,
+        CASE 
+            WHEN ROUND(COALESCE(play_count, 0) / 100000, 2) >= 15 THEN 'Hit'
+            WHEN ROUND(COALESCE(play_count, 0) / 100000, 2) >= 10 THEN 'Known'
+            ELSE 'Underrated'
+        END AS track_category,
+        Dense_RANK() OVER (PARTITION BY genre ORDER BY COALESCE(play_count, 0) DESC) AS genre_rank
+    FROM music.music_track
+),
+HighRated AS (
+    SELECT 
+        genre,
+        COALESCE(
+            STRING_AGG(
+                CASE WHEN rating >= 4.5 THEN track_name ELSE NULL END,
+                ', '
+                ORDER BY track_name
+            ),
+            'None'
+        ) AS high_rated_tracks
+    FROM music.music_track
+    GROUP BY genre
+)
+SELECT 
+    p.track_name,
+    p.genre,
+    p.popularity_metric,
+    p.track_category,
+    p.genre_rank,
+    h.high_rated_tracks
+FROM Popularity p
+JOIN HighRated h ON p.genre = h.genre
+ORDER BY p.genre, p.genre_rank;
+
+--2. Task Description:
+--Calculate rating deviation: absolute difference between track rating and artist’s average rating, rounded to 2 decimals. Use 0 for null rating.
+--Categorize tracks: ‘Consistent’ if deviation ≤ 0.2, ‘Variable’ if ≤ 0.5, else ‘Diverse’.
+--Use a window function to count tracks per artist.
+--Use STRING_AGG to list track names (alphabetically) with play_count ≥ 1,000,000 per artist, comma-separated, or ‘None’ if none.
+--Show: track name, artist, rating deviation, consistency category, artist track count, high-play tracks.
+--Order by artist, rating deviation.
+--Expected Output:
+--track_name	artist	rating_deviation	consistency_category	artist_track_count	high_play_tracks
+--Lose Yourself	Eminem	 0.10	                   Consistent	           2	                 Lose Yourself
+
+WITH ArtistAvg AS (
+    SELECT 
+        artist,
+        AVG(COALESCE(rating, 0)) AS avg_rating
+    FROM music.music_track
+    GROUP BY artist
+),
+TrackStats AS (
+    SELECT 
+        t.track_name,
+        t.artist,
+        ROUND(ABS(COALESCE(t.rating, 0) - a.avg_rating), 2) AS rating_deviation,
+        CASE 
+            WHEN ROUND(ABS(COALESCE(t.rating, 0) - a.avg_rating), 2) <= 0.2 THEN 'Consistent'
+            WHEN ROUND(ABS(COALESCE(t.rating, 0) - a.avg_rating), 2) <= 0.5 THEN 'Variable'
+            ELSE 'Diverse'
+        END AS consistency_category,
+        COUNT(*) OVER (PARTITION BY t.artist) AS artist_track_count
+    FROM music.music_track t
+    JOIN ArtistAvg a ON t.artist = a.artist
+),
+HighPlay AS (
+    SELECT 
+        artist,
+        COALESCE(
+            STRING_AGG(
+                CASE WHEN play_count >= 1000000 THEN track_name ELSE NULL END,
+                ', '
+                ORDER BY track_name
+            ),
+            'None'
+        ) AS high_play_tracks
+    FROM music.music_track
+    GROUP BY artist
+)
+SELECT 
+    ts.track_name,
+    ts.artist,
+    ts.rating_deviation,
+    ts.consistency_category,
+    ts.artist_track_count,
+    hp.high_play_tracks
+FROM TrackStats ts
+JOIN HighPlay hp ON ts.artist = hp.artist
+ORDER BY ts.artist, ts.rating_deviation;
+
+--3: Recent Track Performance
+--Objective: Rank recent tracks by rating and aggregate short tracks by genre.
+--Task Description:
+--For tracks released after 2000, calculate a performance score: rating + (play_count ÷ 500,000), rounded to 2 decimals. Use 0 for null rating or play_count.
+--Categorize tracks: ‘Standout’ if score ≥ 8, ‘Notable’ if ≥ 6, else ‘Average’.
+--Use a window function to rank tracks by performance score within genre (highest = rank 1).
+--Use STRING_AGG to list track names (alphabetically) with duration_seconds ≤ 250 per genre, comma-separated, or ‘None’ if none.
+--Show: track name, genre, performance score, performance category, genre rank, short tracks.
+--Order by performance score (descending).
+--Expected Output:
+--track_name	    genre	performance_score	performance_category	genre_rank	short_tracks
+--Blinding Lights	     Pop	    9.40	            Standout	            1	        Blinding Lights, Shape of You
+
+WITH RecentTracks AS (
+    SELECT 
+        track_name,
+        genre,
+        ROUND(COALESCE(rating, 0) + COALESCE(play_count, 0) / 500000, 2) AS performance_score,
+        CASE 
+            WHEN ROUND(COALESCE(rating, 0) + COALESCE(play_count, 0) / 500000, 2) >= 8 THEN 'Standout'
+            WHEN ROUND(COALESCE(rating, 0) + COALESCE(play_count, 0) / 500000, 2) >= 6 THEN 'Notable'
+            ELSE 'Average'
+        END AS performance_category,
+        RANK() OVER (PARTITION BY genre ORDER BY ROUND(COALESCE(rating, 0) + COALESCE(play_count, 0) / 500000, 2) DESC) AS genre_rank
+    FROM music.music_track
+    WHERE release_date > '2000-01-01'
+),
+ShortTracks AS (
+    SELECT 
+        genre,
+        COALESCE(
+            STRING_AGG(
+                CASE WHEN duration_seconds <= 250 THEN track_name ELSE NULL END,
+                ', '
+                ORDER BY track_name
+            ),
+            'None'
+        ) AS short_tracks
+    FROM music.music_track
+    WHERE release_date > '2000-01-01'
+    GROUP BY genre
+)
+SELECT 
+    rt.track_name,
+    rt.genre,
+    rt.performance_score,
+    rt.performance_category,
+    rt.genre_rank,
+    st.short_tracks
+FROM RecentTracks rt
+JOIN ShortTracks st ON rt.genre = st.genre
+ORDER BY rt.performance_score DESC;


### PR DESCRIPTION
CREATE TABLE music.music_track (
    track_id SERIAL PRIMARY KEY,
    track_name VARCHAR(100) NOT NULL,
    artist VARCHAR(100) NOT NULL,
    genre VARCHAR(50) CHECK (genre IN ('Pop', 'Rock', 'Jazz', 'Hip-Hop', 'Classical')),
    release_date DATE,
    duration_seconds INTEGER CHECK (duration_seconds > 0),
    play_count INTEGER CHECK (play_count >= 0),
    rating NUMERIC(3, 1) CHECK (rating >= 0 AND rating <= 5)
);

INSERT INTO music.music_track (track_name, artist, genre, release_date, duration_seconds, play_count, rating) VALUES
('Bohemian Rhapsody', 'Queen', 'Rock', '1975-10-31', 354, 1500000, 4.8),
('Shape of You', 'Ed Sheeran', 'Pop', '2017-01-06', 233, 2000000, 4.2),
('Billie Jean', 'Michael Jackson', 'Pop', '1983-01-02', 294, 1200000, 4.5),
('Take Five', 'Dave Brubeck', 'Jazz', '1959-09-29', 324, 300000, 4.0),
('Lose Yourself', 'Eminem', 'Hip-Hop', '2002-10-28', 326, 1800000, 4.7),
('Moonlight Sonata', 'Beethoven', 'Classical', '1801-01-01', 360, 200000, 4.3),
('Sweet Child O''Mine', 'Guns N'' Roses', 'Rock', '1987-07-21', 356, 1100000, 4.6),
('Blinding Lights', 'The Weeknd', 'Pop', '2019-11-29', 200, 2500000, 4.4),
('Kind of Blue', 'Miles Davis', 'Jazz', NULL, 274, 250000, 4.1),
('Stan', 'Eminem', 'Hip-Hop', '2000-11-21', 405, 900000, 4.5);
Tasks for Interns
Below are three short, tricky tasks emphasizing STRING_AGG and window functions using the music_track table.

Task 1: Genre Popularity Aggregation
Objective: Rank tracks by play count within genres and aggregate popular tracks.

Task Description: Without Function

Calculate a popularity metric: play_count ÷ 100,000, rounded to 2 decimals. Use 0 for null play_count.
Categorize tracks: ‘Hit’ if metric ≥ 15, ‘Known’ if ≥ 10, else ‘Underrated’.
Use a window function to rank tracks by play_count within each genre (highest = rank 1).
Use STRING_AGG to list track names (alphabetically) with rating ≥ 4.5 per genre, comma-separated, or ‘None’ if none.
Show: track name, genre, popularity metric, category, genre rank, high-rated tracks.
Order by genre, genre rank.
Expected Output:


track_name	    genre	popularity_metric	track_category	genre_rank	high_rated_tracks
Blinding Lights	     Pop	    25.00	            Hit	            1	        Billie Jean, Blinding Lights
...	...	...	...	...	...


2. Task Description:

Calculate rating deviation: absolute difference between track rating and artist’s average rating, rounded to 2 decimals. Use 0 for null rating.
Categorize tracks: ‘Consistent’ if deviation ≤ 0.2, ‘Variable’ if ≤ 0.5, else ‘Diverse’.
Use a window function to count tracks per artist.
Use STRING_AGG to list track names (alphabetically) with play_count ≥ 1,000,000 per artist, comma-separated, or ‘None’ if none.
Show: track name, artist, rating deviation, consistency category, artist track count, high-play tracks.
Order by artist, rating deviation.
Expected Output:


track_name	artist	rating_deviation	consistency_category	artist_track_count	high_play_tracks
Lose Yourself	Eminem	 0.10	                   Consistent	           2	                 Lose Yourself
...	...	...	...	...	...


3: Recent Track Performance
Objective: Rank recent tracks by rating and aggregate short tracks by genre.

Task Description:

For tracks released after 2000, calculate a performance score: rating + (play_count ÷ 500,000), rounded to 2 decimals. Use 0 for null rating or play_count.
Categorize tracks: ‘Standout’ if score ≥ 8, ‘Notable’ if ≥ 6, else ‘Average’.
Use a window function to rank tracks by performance score within genre (highest = rank 1).
Use STRING_AGG to list track names (alphabetically) with duration_seconds ≤ 250 per genre, comma-separated, or ‘None’ if none.
Show: track name, genre, performance score, performance category, genre rank, short tracks.
Order by performance score (descending).
Expected Output:


track_name	    genre	performance_score	performance_category	genre_rank	short_tracks
Blinding Lights	     Pop	    9.40	            Standout	            1	        Blinding Lights, Shape of You
...	...	...	...	...	...

